### PR TITLE
Fix/get orderform

### DIFF
--- a/src/actions/CartActions.js
+++ b/src/actions/CartActions.js
@@ -22,6 +22,20 @@ class CartActions {
   }
 
   addToCart(data) {
+    if(!data.orderFormId) {
+      Fetcher.getOrderForm().then((response) => {
+        data.orderFormId = response.data.orderFormId;
+        this.actions.orderFormSuccess.defer(response.data);
+        this.actions.executeAddToCart.defer(data);
+      }).catch(() => {
+        this.actions.orderFormFailed.defer('Ocorreu um erro ao inicializar o carrinho');
+      });
+    } else {
+      this.actions.executeAddToCart.defer(data);
+    }
+  }
+
+  executeAddToCart(data) {
     this.dispatch();
 
     Fetcher.addToCart(data.orderFormId, data.item).then((response) => {
@@ -36,6 +50,20 @@ class CartActions {
   }
 
   updateCart(data) {
+    if(!data.orderFormId) {
+      Fetcher.getOrderForm().then((response) => {
+        data.orderFormId = response.data.orderFormId;
+        this.actions.orderFormSuccess.defer(response.data);
+        this.actions.executeUpdateCart.defer(data);
+      }).catch(() => {
+        this.actions.orderFormFailed.defer('Ocorreu um erro ao inicializar o carrinho');
+      });
+    } else {
+      this.actions.executeUpdateCart.defer(data);
+    }
+  }
+
+  executeUpdateCart(data) {
     this.dispatch();
 
     Fetcher.updateItems(data.orderFormId, data.item).then((response) => {
@@ -64,6 +92,20 @@ class CartActions {
   }
 
   setShipping(data) {
+    if(!data.orderFormId) {
+      Fetcher.getOrderForm().then((response) => {
+        data.orderFormId = response.data.orderFormId;
+        this.actions.orderFormSuccess.defer(response.data);
+        this.actions.executeSetShipping.defer(data);
+      }).catch(() => {
+        this.actions.orderFormFailed.defer('Ocorreu um erro ao inicializar o carrinho');
+      });
+    } else {
+      this.actions.executeSetShipping.defer(data);
+    }
+  }
+
+  executeSetShipping(data) {
     this.dispatch();
 
     Fetcher.setShipping(data.orderFormId, data.address).then(() => {
@@ -74,6 +116,20 @@ class CartActions {
   }
 
   setCheckedIn(orderFormId) {
+    if(!orderFormId) {
+      Fetcher.getOrderForm().then((response) => {
+        orderFormId = response.data.orderFormId;
+        this.actions.orderFormSuccess.defer(response.data);
+        this.actions.executeSetCheckedIn.defer(orderFormId);
+      }).catch(() => {
+        this.actions.orderFormFailed.defer('Ocorreu um erro ao inicializar o carrinho');
+      });
+    } else {
+      this.actions.executeSetCheckedIn.defer(orderFormId);
+    }
+  }
+
+  executeSetCheckedIn(orderFormId) {
     this.dispatch();
 
     Fetcher.setCheckedIn(orderFormId).then((response) => {

--- a/src/actions/CheckoutActions.js
+++ b/src/actions/CheckoutActions.js
@@ -3,23 +3,36 @@ import flux from '../flux';
 import Fetcher from 'utils/Fetcher';
 
 class CheckoutActions {
-  addCustomerEmail(data) {
+  setClientData(data) {
+    if(!data.orderForm) {
+      Fetcher.getOrderForm().then((response) => {
+        data.orderForm = response.data.orderForm;
+        this.actions.executeSetClientData.defer(data);
+      }).catch(() => {
+        this.actions.orderFormFailed.defer('Ocorreu um erro ao inicializar o carrinho');
+      });
+    } else {
+      this.actions.executeSetClientData.defer(data);
+    }
+  }
+
+  executeSetClientData(data) {
     this.dispatch(data.email);
 
     data.email = data.email || Date.now().toString() + '@vtex-instore.com';
 
     Fetcher.setClientProfile(data.orderForm, data.email).then(() => {
-      this.actions.setEmailSuccess.defer();
+      this.actions.setClientDataSuccess.defer();
     }).catch(() => {
-      this.actions.setEmailFailed.defer('Ocorreu um erro ao setar os dados do cliente');
+      this.actions.setClientDataFailed.defer('Ocorreu um erro ao setar os dados do cliente');
     });
   }
 
-  setEmailSuccess() {
+  setClientDataSuccess() {
     this.dispatch();
   }
 
-  setEmailFailed(errorMessage) {
+  setClientDataFailed(errorMessage) {
     this.dispatch(errorMessage);
   }
 

--- a/src/components/UserAuthentication/index.js
+++ b/src/components/UserAuthentication/index.js
@@ -25,13 +25,13 @@ export default class Authentication extends React.Component {
     e.preventDefault();
 
     if(this.state.email) {
-      CheckoutActions.addCustomerEmail({email: this.state.email, orderForm: this.props.orderForm.orderFormId});
+      CheckoutActions.setClientData({email: this.state.email, orderForm: this.props.orderForm.orderFormId});
       this.props.history.pushState(null, '/shop');
     }
   }
 
   handleAnonymous() {
-    CheckoutActions.addCustomerEmail({email: '', orderForm: this.props.orderForm.orderFormId});
+    CheckoutActions.setClientData({email: '', orderForm: this.props.orderForm.orderFormId});
   }
 
   render() {

--- a/src/stores/CartStore.js
+++ b/src/stores/CartStore.js
@@ -45,7 +45,7 @@ class CartStore {
     this.setState(this.state.set('error', errorMessage));
   }
 
-  onAddToCart() {
+  onExecuteAddToCart() {
     this.setState(this.state.set('addLoading', true));
     this.setState(this.state.set('loading', true));
     this.setState(this.state.set('addError', ''));
@@ -58,7 +58,7 @@ class CartStore {
     this.setState(this.state.set('error', errorMessage));
   }
 
-  onUpdateCart() {
+  onExecuteUpdateCart() {
     this.setState(this.state.set('updateLoading', true));
     this.setState(this.state.set('loading', true));
     this.setState(this.state.set('updateError', ''));
@@ -71,11 +71,11 @@ class CartStore {
     this.setState(this.state.set('error', errorMessage));
   }
 
-  onSetShipping() {
+  onExecuteSetShipping() {
     this.setState(this.state.set('error', ''));
   }
 
-  onSetCheckedIn() {
+  onExecuteSetCheckedIn() {
     this.setState(this.state.set('error', ''));
   }
 

--- a/src/stores/CheckoutStore.js
+++ b/src/stores/CheckoutStore.js
@@ -23,12 +23,12 @@ class CheckoutStore {
     });
   }
 
-  onAddCustomerEmail(email) {
+  onExecuteSetClientData(email) {
     this.setState(this.state.set('customerEmail', email));
     this.setState(this.state.set('error', ''));
   }
 
-  onSetEmailFailed(errorMessage) {
+  onSetClientDataFailed(errorMessage) {
     this.setState(this.state.set('error', errorMessage));
   }
 


### PR DESCRIPTION
Essa mudança foi para tentar resolver o problema do OrderForm não estar disponível na tela de adicionar produto.

Antes, pegávamos o OrderForm na tela de Identificação apenas.

Agora, caso nos requests seguintes o OrderForm ainda esteja `undefined`, fazemos outro request ao OrderForm para fazer a requisição desejada.